### PR TITLE
Add AES256_CTS_HMAC specific hash format

### DIFF
--- a/minikerberos/ccache.py
+++ b/minikerberos/ccache.py
@@ -94,11 +94,15 @@ class Credential:
 		else:
 			tgs_name_string        = res['sname']['name-string'][1]
 		tgs_realm              = res['realm']
-		tgs_checksum           = res['enc-part']['cipher'][:16]
-		tgs_encrypted_data2    = res['enc-part']['cipher'][16:]
+		if tgs_encryption_type == EncryptionType.AES256_CTS_HMAC_SHA1_96.value:
+			tgs_checksum           = res['enc-part']['cipher'][-12:]
+			tgs_encrypted_data2    = res['enc-part']['cipher'][:-12:]
+			return '$krb5tgs$%s$%s$%s$%s$%s' % (tgs_encryption_type,tgs_name_string,tgs_realm, tgs_checksum.hex(), tgs_encrypted_data2.hex() )
+		else:
+			tgs_checksum           = res['enc-part']['cipher'][:16]
+			tgs_encrypted_data2    = res['enc-part']['cipher'][16:]
+			return '$krb5tgs$%s$*%s$%s$spn*$%s$%s' % (tgs_encryption_type,tgs_name_string,tgs_realm, tgs_checksum.hex(), tgs_encrypted_data2.hex() )
 
-		return '$krb5tgs$%s$*%s$%s$spn*$%s$%s' % (tgs_encryption_type,tgs_name_string,tgs_realm, tgs_checksum.hex(), tgs_encrypted_data2.hex() )
-	
 	def to_tgt(self):
 		"""
 		Returns the native format of an AS_REP message and the sessionkey in EncryptionKey native format


### PR DESCRIPTION
According to [hashcat's module](https://github.com/hashcat/hashcat/blob/master/src/modules/module_19700.c) (also reflected in the [Impacket implementation](https://github.com/SecureAuthCorp/impacket/blob/master/examples/GetUserSPNs.py#L215)), the `aes256-cts-hmac-sha1-96` hash format is not correct in the current implementation. This PR aims to fix it.

Note: the *spn* being optional in the *hashcat* format, it is not included here.