### PR TITLE
add krb5 gssapi ap-req token generation function

### DIFF
--- a/minikerberos/protocol/asn1_structs.py
+++ b/minikerberos/protocol/asn1_structs.py
@@ -785,6 +785,22 @@ class AD_IF_RELEVANT(AuthorizationData):
 	pass
 
 
+class GSSAPIOID(core.ObjectIdentifier):
+	_map = {
+		'1.2.840.113554.1.2.2': 'krb5',
+	}
+
+	_reverse_map = {
+		'krb5': '1.2.840.113554.1.2.2',
+	}
+
+
+class GSSAPIToken(core.Asn1Value):
+	class_ = 1
+	tag = 0
+	method = 1
+
+
 #	
 #DOMAIN-X500-COMPRESS	krb5int32 ::= 1
 #


### PR DESCRIPTION
#### Function
* add krb5 gssapi ap-req token generation function
  * https://tools.ietf.org/html/rfc4121#section-4.1
  * http://oid-info.com/get/1.2.840.113554.1.2.2


#### Test Code
```py
from minikerberos.common.creds import KerberosCredential
from minikerberos.common.constants import KerberosSocketType
from minikerberos.client import KerbrosClient
from minikerberos.common.spn import KerberosSPN

from minikerberos.protocol.structures import KRB5Token

cred = KerberosCredential.from_keytab(keytab_file, user, realm)
        target = KerberosTarget()
        target.ip = kdc['host']
        target.port = kdc['port']
        target.protocol = KerberosSocketType.TCP
client = KerbrosClient(cred, target)
client.get_TGT()

spn = KerberosSPN()
spn.username = user
spn.service = service
spn.domain = realm
tgs, enc, key = client.get_TGS(spn)

token = client.construct_apreq(tgs=tgs, encTGSRepPart=enc, sessionkey=key, flags=0)
headers = {'Authorization': 'Negotiate ' + KRB5Token(token).get_apreq_token()} # Add token to http protocol auth header
```

Signed-off-by: sunwoo shin sunwoo.shin@navercorp.com