### PR TITLE
modify not to read credential cache configuration entries

### DIFF
--- a/minikerberos/common/ccache.py
+++ b/minikerberos/common/ccache.py
@@ -658,7 +658,10 @@ class CCACHE:
 		eof = reader.tell()
 		reader.seek(pos,0)
 		while reader.tell() < eof:
-			c.credentials.append(Credential.parse(reader))
+			cred = Credential.parse(reader)
+			if not (len(cred.server.components) > 0 and cred.server.components[0].to_string() == 'krb5_ccache_conf_data'
+			and cred.server.realm.to_string() == 'X-CACHECONF:'):
+				c.credentials.append(cred)
 		
 		return c
 		


### PR DESCRIPTION
### issue
An error occurs when credential cache configuration entries is included in ccache.
* https://web.mit.edu/kerberos/krb5-devel/doc/formats/ccache_file_format.html#credential-cache-configuration-entries
### error message
```
Traceback (most recent call last):
File "test.py", line 387, in test                                                                                            
    CCACHE.parse(io.BytesIO(bytearray(file.read()))).get_all_tgt())), None)
File "/root/.local/lib/python3.6/site-packages/minikerberos/common/ccache.py", line 596, in get_all_tgt                                                                                             
    tgt = [cred.to_tgt(), cred.time]
File "/root/.local/lib/python3.6/site-packages/minikerberos/common/ccache.py", line 119, in to_tgt                                                                                                  
    tgt_rep['ticket'] = Ticket.load(self.ticket.to_asn1()).native
File "/usr/local/lib/python3.6/site-packages/asn1crypto/core.py", line 230, in load
    value, _ = _parse_build(encoded_data, spec=spec, spec_params=kwargs, strict=strict)
File "/usr/local/lib/python3.6/site-packages/asn1crypto/core.py", line 5668, in _parse_build
    info, new_pointer = _parse(encoded_data, encoded_len, pointer)
File "/usr/local/lib/python3.6/site-packages/asn1crypto/parser.py", line 225, in _parse
    raise ValueError(_INSUFFICIENT_DATA_MESSAGE % (contents_end, data_len))
ValueError: Insufficient data - 103 bytes requested but only 3 available
```

### Debug View
<img width="788" alt="e50f5980-4b99-11eb-8564-8928f4c6193d" src="https://user-images.githubusercontent.com/62536685/103498118-fea8ed80-4e86-11eb-845f-735a086f57cd.png">

Signed-off-by: sunwoo shin sunwoo.shin@navercorp.com