### PR TITLE
Handle errormsg not found in KerberosError

### DIFF
--- a/minikerberos/protocol/errors.py
+++ b/minikerberos/protocol/errors.py
@@ -9,15 +9,15 @@ class KerberosError(Exception):
 	def __init__(self, krb_err_msg, extra_msg = ''):
 		self.krb_err_msg = krb_err_msg.native
 		self.errorcode = KerberosErrorCode.ERR_NOT_FOUND
-		self.errormsg = 'Error code not found! Err code: %s' % self.krb_err_msg['error-code']
+		self.errormsg = 'Error message not found! Err code: %s' % self.krb_err_msg['error-code']
 		try:
 			self.errorcode = KerberosErrorCode(self.krb_err_msg['error-code'])
-			self.errormsg = KerberosErrorMessage[self.errorcode.name]
+			self.errormsg = KerberosErrorMessage[self.errorcode.name].value
 		except:
 			pass
 		self.extra_msg = extra_msg
 		
-		super(Exception, self).__init__('%s Error Code: %d Reason: %s ' % (extra_msg, self.errorcode.value, self.errormsg.value))
+		super(Exception, self).__init__('%s Error Name: %s Detail: "%s" ' % (extra_msg, self.errorcode.name, self.errormsg))
 	
 		
 


### PR DESCRIPTION
Handle the case where there is no matching message in the KerberosErrorMessage Enum for the krb_err_msg['error-code'], in this case:
- errormsg is a str and not enum so errormsg.value doesn't exist
- Sometimes a KerberosErrorCode Enum entry exist but no KerberosErrorMessage so it's more interesting to put the KerberosErrorCode name (more informational) than the value because the value will be repeated in the errormsg anyway (see '... Err code: %s')
- When there is no matching entry for KerberosErrorMessage, the corresponding error message hasn't been found and not the error code so 'Error message not found!' is more accurate