### PR TITLE
Change the way principal components are used in keytab files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# idea
+.idea/

--- a/minikerberos/aioclient.py
+++ b/minikerberos/aioclient.py
@@ -90,7 +90,7 @@ class AIOKerberosClient:
 		
 		kdc_req_body = {}
 		kdc_req_body['kdc-options'] = KDCOptions(set(kdcopts))
-		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		kdc_req_body['realm'] = self.usercreds.domain.upper()
 		kdc_req_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': ['krbtgt', self.usercreds.domain.upper()]})
 		kdc_req_body['till'] = (now + datetime.timedelta(days=1)).replace(microsecond=0)
@@ -117,7 +117,7 @@ class AIOKerberosClient:
 
 		kdc_req_body_data = {}
 		kdc_req_body_data['kdc-options'] = KDCOptions(set(kdcopts))
-		kdc_req_body_data['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		kdc_req_body_data['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		kdc_req_body_data['realm'] = self.usercreds.domain.upper()
 		kdc_req_body_data['sname'] = PrincipalName({'name-type': NAME_TYPE.SRV_INST.value, 'name-string': ['krbtgt', self.usercreds.domain.upper()]})
 		kdc_req_body_data['till']  = (now + datetime.timedelta(days=1)).replace(microsecond=0)
@@ -199,7 +199,7 @@ class AIOKerberosClient:
 			for tgt, keystruct in self.ccache.get_all_tgt():
 				if self.usercreds.ccache_spn_strict_check is True:
 					our_user = str(self.usercreds.username) + '@' + self.usercreds.domain
-					ticket_for = tgt['cname']['name-string'][0] + '@' + tgt['crealm']
+					ticket_for = '/'.join(tgt['cname']['name-string']) + '@' + tgt['crealm']
 					if ticket_for.upper() == our_user.upper():
 						logger.debug('Found TGT for user %s' % our_user)
 						self.kerberos_TGT = tgt
@@ -270,7 +270,7 @@ class AIOKerberosClient:
 		now = datetime.datetime.now(datetime.timezone.utc)
 		kdc_req_body = {}
 		kdc_req_body['kdc-options'] = KDCOptions(set(kdcopts))
-		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		kdc_req_body['realm'] = self.usercreds.domain.upper()
 		kdc_req_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': ['krbtgt', self.usercreds.domain.upper()]})
 		kdc_req_body['till']  = (now + datetime.timedelta(days=1)).replace(microsecond=0)
@@ -499,7 +499,7 @@ class AIOKerberosClient:
 		
 		krb_tgs_body = {}
 		krb_tgs_body['kdc-options'] = KDCOptions(set(kdcopts))
-		krb_tgs_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		krb_tgs_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		krb_tgs_body['realm'] = self.usercreds.domain.upper()
 		krb_tgs_body['till'] = (now + datetime.timedelta(days=1)).replace(microsecond=0)
 		krb_tgs_body['nonce'] = secrets.randbits(31)
@@ -607,7 +607,6 @@ class AIOKerberosClient:
 		pa_for_user['padata-value'] = PA_FOR_USER_ENC(pa_for_user_enc).dump()
 	
 		###### Constructing body
-		spn_user = [self.usercreds.username]
 		if spn_user is not None:
 			if isinstance(spn_user, str):
 				spn_user = [spn_user]
@@ -615,6 +614,8 @@ class AIOKerberosClient:
 				spn_user = spn_user
 			else:
 				spn_user = spn_user.get_principalname()
+		else:
+			spn_user = self.usercreds.username.split('/')
 
 		
 		krb_tgs_body = {}

--- a/minikerberos/client.py
+++ b/minikerberos/client.py
@@ -84,7 +84,7 @@ class KerbrosClient:
 		
 		kdc_req_body = {}
 		kdc_req_body['kdc-options'] = KDCOptions(set(kdcopts))
-		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		kdc_req_body['realm'] = self.usercreds.domain.upper()
 		kdc_req_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': ['krbtgt', self.usercreds.domain.upper()]})
 		kdc_req_body['till'] = (now + datetime.timedelta(days=1)).replace(microsecond=0)
@@ -111,7 +111,7 @@ class KerbrosClient:
 
 		kdc_req_body_data = {}
 		kdc_req_body_data['kdc-options'] = KDCOptions(set(kdcopts))
-		kdc_req_body_data['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		kdc_req_body_data['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		kdc_req_body_data['realm'] = self.usercreds.domain.upper()
 		kdc_req_body_data['sname'] = PrincipalName({'name-type': NAME_TYPE.SRV_INST.value, 'name-string': ['krbtgt', self.usercreds.domain.upper()]})
 		kdc_req_body_data['till']  = (now + datetime.timedelta(days=1)).replace(microsecond=0)
@@ -221,7 +221,7 @@ class KerbrosClient:
 		now = datetime.datetime.now(datetime.timezone.utc)
 		kdc_req_body = {}
 		kdc_req_body['kdc-options'] = KDCOptions(set(['forwardable','renewable','proxiable']))
-		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		kdc_req_body['cname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		kdc_req_body['realm'] = self.usercreds.domain.upper()
 		kdc_req_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': ['krbtgt', self.usercreds.domain.upper()]})
 		kdc_req_body['till']  = (now + datetime.timedelta(days=1)).replace(microsecond=0)
@@ -445,7 +445,6 @@ class KerbrosClient:
 		pa_for_user['padata-value'] = PA_FOR_USER_ENC(pa_for_user_enc).dump()
 	
 		###### Constructing body
-		spn_user = [self.usercreds.username]
 		if spn_user is not None:
 			if isinstance(spn_user, str):
 				spn_user = [spn_user]
@@ -453,6 +452,8 @@ class KerbrosClient:
 				spn_user = spn_user
 			else:
 				spn_user = spn_user.get_principalname()
+		else:
+			spn_user = self.usercreds.username.split('/')
 
 		krb_tgs_body = {}
 		krb_tgs_body['kdc-options'] = KDCOptions(set(kdcopts))
@@ -751,7 +752,7 @@ class KerbrosClient:
 		
 		krb_tgs_body = {}
 		krb_tgs_body['kdc-options'] = KDCOptions(set(kdcopts))
-		krb_tgs_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': [self.usercreds.username]})
+		krb_tgs_body['sname'] = PrincipalName({'name-type': NAME_TYPE.PRINCIPAL.value, 'name-string': self.usercreds.username.split('/')})
 		krb_tgs_body['realm'] = self.usercreds.domain.upper()
 		krb_tgs_body['till'] = (now + datetime.timedelta(days=1)).replace(microsecond=0)
 		krb_tgs_body['nonce'] = secrets.randbits(31)

--- a/minikerberos/common/creds.py
+++ b/minikerberos/common/creds.py
@@ -208,7 +208,7 @@ class KerberosCredential:
 		return KerberosCredential.from_kirbi(keytab_file_path, principal, realm)
 	
 	@staticmethod
-	def from_keytab_string(self, keytabdata: str|bytes, principal: str, realm: str) -> KerberosCredential:
+	def from_keytab_string(keytabdata: str | bytes, principal: str, realm: str) -> KerberosCredential:
 		cred = KerberosCredential()
 		cred.username = principal
 		cred.domain = realm
@@ -220,25 +220,25 @@ class KerberosCredential:
 
 		for keytab_entry in keytab.entries:
 			if realm == keytab_entry.principal.realm.to_string():
-				for keytab_principal in keytab_entry.principal.components:
-					if principal == keytab_principal.to_string():
-						enctype = None
-						if Enctype.AES256 == keytab_entry.enctype:
-							enctype = KerberosSecretType.AES256
-						elif Enctype.AES128 == keytab_entry.enctype:
-							enctype = KerberosSecretType.AES128
-						elif Enctype.DES3 == keytab_entry.enctype:
-							enctype = KerberosSecretType.DES3
-						elif Enctype.DES_CRC == keytab_entry.enctype:
-							enctype = KerberosSecretType.DES
-						elif Enctype.DES_MD4 == keytab_entry.enctype:
-							enctype = KerberosSecretType.DES
-						elif Enctype.DES_MD5 == keytab_entry.enctype:
-							enctype = KerberosSecretType.DES
-						elif Enctype.RC4 == keytab_entry.enctype:
-							enctype = KerberosSecretType.RC4
-						if enctype:
-							cred.add_secret(enctype, keytab_entry.key_contents.hex())
+				keytab_principal = '/'.join(list(map(lambda c: c.to_string(), keytab_entry.principal.components)))
+				if principal == keytab_principal:
+					enctype = None
+					if Enctype.AES256 == keytab_entry.enctype:
+						enctype = KerberosSecretType.AES256
+					elif Enctype.AES128 == keytab_entry.enctype:
+						enctype = KerberosSecretType.AES128
+					elif Enctype.DES3 == keytab_entry.enctype:
+						enctype = KerberosSecretType.DES3
+					elif Enctype.DES_CRC == keytab_entry.enctype:
+						enctype = KerberosSecretType.DES
+					elif Enctype.DES_MD4 == keytab_entry.enctype:
+						enctype = KerberosSecretType.DES
+					elif Enctype.DES_MD5 == keytab_entry.enctype:
+						enctype = KerberosSecretType.DES
+					elif Enctype.RC4 == keytab_entry.enctype:
+						enctype = KerberosSecretType.RC4
+					if enctype:
+						cred.add_secret(enctype, keytab_entry.key_contents.hex())
 		
 		return cred
 


### PR DESCRIPTION
### issue
The principal information in the keytab file is composed of several component information, and is generally used as a name by combining it with `/` separator.

* Example: a/b@R, a/b/c@R, ...

Therefore, when comparing the keytab and principal values, it seems necessary to compare the component information of the keytab with `/` separators.

### Related krb5 codes
* https://github.com/krb5/krb5/blob/34625d594c339a077899fa01fc4b5c331a1647d0/src/lib/krb5/krb/parse.c#L129-L173