### PR TITLE
fix packing issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 	author_email="info@skelsec.com",
 
 	# Packages
-	packages=find_packages(),
+	packages=find_packages(exclude=["tests*"]),
 
 	# Include additional files into the package
 	include_package_data=True,


### PR DESCRIPTION
Sorry again @skelsec . As in https://github.com/skelsec/kerberoast/pull/9 , also minikerberos has the same issue of the `tests` folder in the root python folder. I propose the same solution used for kerberoast for fixing this packing issue.

Thanks