### PR TITLE
Avoid module-level imports of oscrypt

### DIFF
--- a/minikerberos/pkinit.py
+++ b/minikerberos/pkinit.py
@@ -19,9 +19,6 @@ from asn1crypto import core
 from asn1crypto import x509
 from asn1crypto import keys
 
-from oscrypto.keys import parse_pkcs12
-from oscrypto.asymmetric import rsa_pkcs1v15_sign, load_private_key
-
 from minikerberos.protocol.constants import NAME_TYPE, MESSAGE_TYPE, PaDataType
 from minikerberos.protocol.encryption import Enctype, _checksum_table, _enctype_table, Key
 from minikerberos.protocol.structures import AuthenticatorChecksum
@@ -113,6 +110,8 @@ class PKINIT:
 
 	@staticmethod
 	def from_pfx(pfxfile, pfxpass, dh_params = None):
+		from oscrypto.keys import parse_pkcs12
+		from oscrypto.asymmetric import load_private_key
 		pkinit = PKINIT()
 		#print('Loading pfx12')		
 		if isinstance(pfxpass, str):
@@ -330,6 +329,8 @@ class PKINIT:
 		2. the certificate used to sign the data blob
 		3. the singed 'signed_attrs' structure (ASN1) which points to the "data" structure (in point 1)
 		"""
+
+		from oscrypto.asymmetric import rsa_pkcs1v15_sign
 		
 		da = {}
 		da['algorithm'] = algos.DigestAlgorithmId('1.3.14.3.2.26') # for sha1


### PR DESCRIPTION
Let me take this opportunity to thank you for important work on many of your projects, some of which have become a corner stone of the OST community. Your efforts are very appreciated.

Today I'd like to discuss the `oscrypto` dependency. As you are aware, there are issues in some of your projects which depend on minikerberos (https://github.com/skelsec/pypykatz/issues/136, https://github.com/skelsec/msldap/issues/37) due to a bad regex if `openssl` has a double digit patch number. Currently, openssl-3.0.10 is the current version on Kali and Debian unstable and probably more. This is discussed here: https://github.com/wbond/oscrypto/issues/78

I'm not sure why exactly the `oscrypto` dependency is needed, as `cryptography` is already a dependency [due to the `asysocks` dependency](https://github.com/skelsec/asysocks/blob/main/setup.py#L50). I think it could be replaced by `cryptography`, but unfortunately I lack the skills, time and motivation to do this.

To alleviate the issue, I propose to avoid the module-level imports of `oscrypto` and move them to the functions where they are needed by merging this PR. This would allow us to use projects like [LdapRelayScan](https://github.com/zyn3rgy/LdapRelayScan) which need `minikerberos`, but not the `pkinit` module. Note that minikerberos has [over 900 dependents](https://github.com/skelsec/minikerberos/network/dependents) (including forks, not sure how accurate this information is though), even though [only 26 files](https://github.com/search?q=minikerberos.pkinit&type=code) (also including forks and identical files) actually import `minikerberos.pkinit`.

Still, if you manage to remove the `oscrypto` dependency, I'd count that as a win. What do you think?

The original commit message follows. Please note that I could not yet test this change.

-------

Many dependents of minikerberos don't need `PKINIT`, so it makes sense to import `oscrypto` only when needed. Especially because `oscrypto<=1.3.0` does not work when `openssl>=3.0.10`.

See: https://github.com/wbond/oscrypto/issues/78