### PR TITLE
Fix SyntaxWarning in Python 3.12

### DIFF
--- a/minikerberos/examples/getNT.py
+++ b/minikerberos/examples/getNT.py
@@ -17,7 +17,7 @@ def main():
 	import argparse
 	
 	parser = argparse.ArgumentParser(description='Fetches the NT hash for the user. PKI auth required.', formatter_class=argparse.RawDescriptionHelpFormatter, epilog = kerberos_url_help_epilog)
-	parser.add_argument('kerberos_url', help='The kerberos target URL. Example: "kerberos+pfx://TEST.corp\Administrator:admin@10.10.10.2/?certdata=test.pfx"')
+	parser.add_argument('kerberos_url', help=r'The kerberos target URL. Example: "kerberos+pfx://TEST.corp\Administrator:admin@10.10.10.2/?certdata=test.pfx"')
 	parser.add_argument('-v', '--verbose', action='count', default=0)
 	
 	args = parser.parse_args()


### PR DESCRIPTION
in Python 3.12 we have a Syntax Warning:

```
/usr/lib/python3/dist-packages/minikerberos/examples/getNT.py:20: SyntaxWarning: invalid escape sequence '\A'

parser.add_argument('kerberos_url', help='The kerberos target URL. Example: "kerberos+pfx://TEST.corp\Administrator:admin@10.10.10.2/?certdata=test.pfx"')
```