### PR TITLE
Fix encoding for non-ascii char in kerberos authentication

### DIFF
--- a/minikerberos/protocol/asn1_structs.py
+++ b/minikerberos/protocol/asn1_structs.py
@@ -183,6 +183,7 @@ class KerberosString(core.GeneralString):
 	values that contain characters other than those permitted by
 	IA5String...
 	"""
+	_encoding = 'utf-8'
 	
 class SequenceOfKerberosString(core.SequenceOf):
 	_child_spec = KerberosString


### PR DESCRIPTION
With the hack.lu CTF this year and therefore a swedish AD environment it was reported that Kerberos authentication does not work with special chars (e.g. `öäü`) that are present in some localized environments: https://github.com/Pennyw0rth/NetExec/issues/963

The problem is that kerberos uses `utf-8` encoding for Kerberos Strings. However, as of now both minikerberos as well as impacket both use `latin1` as its encoding, resulting in failed authentication with users that contain special chars.
See:
- [[MS-KILE]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/) section 3.1.5.7
- openJDK: https://bugs.openjdk.org/browse/JDK-8200152

A PR to fix the issue in impacket has been opened: https://github.com/fortra/impacket/pull/2068

With both fixes applied, pfx authentication (which uses minikerberos as well as impacket) works as intended now (Before&After):
<img width="1724" height="209" alt="image" src="https://github.com/user-attachments/assets/d4652f49-a57f-4c35-9235-9760fc1ad017" />

Be aware that i have not tested the kerberos protokoll on its own with minikerberos, but i expect the same result as in impacket (failed auth for usernames with `öäü` etc in the name)!