### PR TITLE
Fix renew_till value for kirbi to ccache conversion

### DIFF
--- a/minikerberos/common/ccache.py
+++ b/minikerberos/common/ccache.py
@@ -333,8 +333,8 @@ class Times:
 			if 'starttime' in enc_as_rep_part and enc_as_rep_part['starttime'] else 0
 		t.endtime = dt_to_kerbtime(enc_as_rep_part['endtime']) \
 			if 'endtime' in enc_as_rep_part and enc_as_rep_part['endtime'] else 0
-		t.renew_till = dt_to_kerbtime(enc_as_rep_part['renew_till']) \
-			if 'renew_till' in enc_as_rep_part and enc_as_rep_part['renew_till'] else 0
+		t.renew_till = dt_to_kerbtime(enc_as_rep_part['renew-till']) \
+			if 'renew-till' in enc_as_rep_part and enc_as_rep_part['renew-till'] else 0
 		return t
 	
 	@staticmethod


### PR DESCRIPTION
I noticed renew till value is empty when taking a kirbi ticket and converting it to a ccache ticket. This is because there was a typo on the 'renew-till' key.