### PR TITLE
trim usage of "six" Python 2+3 compatibility shim

### DIFF
--- a/minikerberos/protocol/external/dtypes.py
+++ b/minikerberos/protocol/external/dtypes.py
@@ -13,10 +13,7 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 from struct import pack
-from six import binary_type
 
 from minikerberos.protocol.external.ndr import NDRULONG, NDRUHYPER, NDRSHORT, NDRLONG, NDRPOINTER, NDRUniConformantArray, \
     NDRUniFixedArray, NDR, NDRHYPER, NDRSMALL, NDRPOINTERNULL, NDRSTRUCT, \
@@ -110,7 +107,7 @@ class STR(NDRSTRUCT):
     def __setitem__(self, key, value):
         if key == 'Data':
             try:
-                if not isinstance(value, binary_type):
+                if not isinstance(value, bytes):
                     self.fields[key] = value.encode('utf-8')
                 else:
                     # if it is a binary type (str in Python 2, bytes in Python 3), then we assume it is a raw buffer

--- a/minikerberos/protocol/external/ndr.py
+++ b/minikerberos/protocol/external/ndr.py
@@ -16,12 +16,9 @@
 #   [X] Unions and rest of the structured types
 #   [ ] Documentation for this library, especially the support for Arrays
 #
-from __future__ import division
-from __future__ import print_function
 import random
 import inspect
 from struct import pack, unpack_from, calcsize
-from six import with_metaclass, PY3
 
 from minikerberos import logger as LOG
 from minikerberos.protocol.external.enum import Enum
@@ -407,7 +404,7 @@ class EnumType(type):
     def __getattr__(self, attr):
         return self.enumItems[attr].value
 
-class NDRENUM(with_metaclass(EnumType, NDR)):
+class NDRENUM(NDR, metaclass=EnumType):
     align = 2
     align64 = 4
     structure = (
@@ -725,7 +722,7 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
                 if pad > 0:
                     answer += b'\xdd' * pad
                 if dataClass is None:
-                    if item == 'c' and PY3 and isinstance(each, int):
+                    if item == 'c' and isinstance(each, int):
                         # Special case when dealing with PY3, here we have an integer we need to convert
                         each = bytes([each])
                     answer += pack(item, each)
@@ -932,7 +929,7 @@ class NDRVaryingString(NDRUniVaryingArray):
         # If the string element size is one octet, the terminator is a NULL character. 
         # The terminator for a string of multi-byte characters is the array element zero (0).
         if self["Data"][-1:] != b'\x00':
-            if PY3 and isinstance(self["Data"],list) is False:
+            if isinstance(self["Data"],list) is False:
                 self["Data"] = self["Data"] + b'\x00'
             else:
                 self["Data"] = b''.join(self["Data"]) + b'\x00'

--- a/minikerberos/protocol/external/structure.py
+++ b/minikerberos/protocol/external/structure.py
@@ -7,10 +7,8 @@
 # for more information.
 #
 
-from __future__ import division
-from __future__ import print_function
 from struct import pack, unpack, calcsize
-from six import b, PY3
+from six import b
 
 class Structure:
     """ sublcasses can define commonHdr and/or structure.
@@ -246,21 +244,21 @@ class Structure:
         # asciiz specifier
         if format[:1] == 'z':
             if isinstance(data,bytes):
-                return data + b('\0')
-            return bytes(b(data)+b('\0'))
+                return data + b'\0'
+            return bytes(b(data) + b'\0')
 
         # unicode specifier
         if format[:1] == 'u':
-            return bytes(data+b('\0\0') + (len(data) & 1 and b('\0') or b''))
+            return bytes(data+b'\0\0' + (len(data) & 1 and b'\0' or b''))
 
         # DCE-RPC/NDR string specifier
         if format[:1] == 'w':
             if len(data) == 0:
-                data = b('\0\0')
+                data = b'\0\0'
             elif len(data) % 2:
-                data = b(data) + b('\0')
+                data = b(data) + b'\0'
             l = pack('<L', len(data)//2)
-            return b''.join([l, l, b('\0\0\0\0'), data])
+            return b''.join([l, l, b'\0\0\0\0', data])
 
         if data is None:
             raise Exception("Trying to pack None")
@@ -357,16 +355,13 @@ class Structure:
 
         # asciiz specifier
         if format == 'z':
-            if data[-1:] != b('\x00'):
+            if data[-1:] != b'\x00':
                 raise Exception("%s 'z' field is not NUL terminated: %r" % (field, data))
-            if PY3:
-                return data[:-1].decode('latin-1')
-            else:
-                return data[:-1]
+            return data[:-1].decode('latin-1')
 
         # unicode specifier
         if format == 'u':
-            if data[-2:] != b('\x00\x00'):
+            if data[-2:] != b'\x00\x00':
                 raise Exception("%s 'u' field is not NUL-NUL terminated: %r" % (field, data))
             return data[:-2] # remove trailing NUL
 
@@ -520,11 +515,11 @@ class Structure:
 
         # asciiz specifier
         if format[:1] == 'z':
-            return data.index(b('\x00'))+1
+            return data.index(b'\x00')+1
 
         # asciiz specifier
         if format[:1] == 'u':
-            l = data.index(b('\x00\x00'))
+            l = data.index(b'\x00\x00')
             return l + (l & 1 and 3 or 2)
 
         # DCE-RPC/NDR string specifier
@@ -580,7 +575,7 @@ class Structure:
         if format in ['z',':','u']:
             return b''
         if format == 'w':
-            return b('\x00\x00')
+            return b'\x00\x00'
 
         return 0
 
@@ -658,4 +653,4 @@ def parse_bitmask(dict, value):
     if len(ret) == 0:
         return '0'
     else:
-        return ret[:-3]
+        return ret[:-3

--- a/minikerberos/tickettest.py
+++ b/minikerberos/tickettest.py
@@ -46,8 +46,6 @@
 #   [ ] When -request is specified, we could ask for a user2user ticket and also populate the received PAC
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import datetime
 import logging


### PR DESCRIPTION
this is a Python3-only project relying on `from __future__ import annotations` 